### PR TITLE
Fix write method and add configuration tests

### DIFF
--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -1,8 +1,7 @@
 import json
 import os
-from functools import reduce
 
-from typing import Any, List, Dict, Tuple
+from typing import Any, List
 
 
 class Configuration:

--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -31,11 +31,11 @@ class Configuration:
         if isinstance(keys, str):
             self.config[keys] = value
             return self
+
+        cfg = self.config
         for key in keys[:-1]:
-            if key not in self.config:
-                self.config[key] = {}
-            self.config = self.config[key]
-        self.config[keys[-1]] = value
+            cfg = cfg.setdefault(key, {})
+        cfg[keys[-1]] = value
         return self
 
     def write_dict(self, to_write: dict):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.configuration import Configuration
+
+
+def test_multiple_writes_preserve_configuration(tmp_path):
+    config_file = tmp_path / "config.json"
+    cfg = Configuration(config_file)
+    cfg.write(["section", "item1"], 1)
+    cfg.write(["section", "item2"], 2)
+    assert cfg.config == {"section": {"item1": 1, "item2": 2}}
+    assert cfg.read(["section", "item1"]) == 1
+    assert cfg.read(["section", "item2"]) == 2
+
+
+def test_write_with_mixed_keys(tmp_path):
+    config_file = tmp_path / "config.json"
+    cfg = Configuration(config_file)
+    cfg.write("root", "value")
+    cfg.write(["nested", "key"], "value2")
+    assert cfg.config == {"root": "value", "nested": {"key": "value2"}}
+    assert cfg.read(["nested", "key"]) == "value2"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,9 +1,9 @@
-import sys
-from pathlib import Path
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
-from modules.configuration import Configuration
+from modules.configuration import Configuration  # noqa: E402
 
 
 def test_multiple_writes_preserve_configuration(tmp_path):


### PR DESCRIPTION
## Summary
- fix Configuration.write to avoid overwriting internal state
- test configuration persistence across multiple writes

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851905a58e883248df2687c6b0cc6bf