### PR TITLE
Run async test without plugin

### DIFF
--- a/tests/test_cloner_cog.py
+++ b/tests/test_cloner_cog.py
@@ -96,8 +96,7 @@ class DummyCtx:
         pass
 
 
-@pytest.mark.asyncio
-async def test_process_start_respects_last_method(monkeypatch):
+def test_process_start_respects_last_method(monkeypatch):
     cog = ClonerCog(bot=None)
     dummy = DummyCloner(last_method="clone_icon")
     cog.cloners.append(dummy)
@@ -107,7 +106,7 @@ async def test_process_start_respects_last_method(monkeypatch):
     monkeypatch.setattr(cc, "logger", dummy.logger, raising=False)
 
     ctx = DummyCtx()
-    await ClonerCog.process.callback(cog, ctx, args_str="start=true save=false")
+    asyncio.run(ClonerCog.process.callback(cog, ctx, args_str="start=true save=false"))
 
     assert "clone_icon" not in dummy.executed
     expected = [


### PR DESCRIPTION
## Summary
- remove pytest-asyncio dependency by rewriting the test
- ensure async function executed using `asyncio.run`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851995e6b9c8324951b04b808cece86